### PR TITLE
Allow for better testing of eventhandler by making it swallow exception only optionally

### DIFF
--- a/eventhandler/management/commands/event_listener.py
+++ b/eventhandler/management/commands/event_listener.py
@@ -15,7 +15,7 @@ class Command(BaseCommand):
            'correct event handler'
 
     def handle(self, *args, **options):
-        dispatcher = Dispatcher(before_handler=_before, error_on_missing_type=False)
+        dispatcher = Dispatcher(before_handler=_before, error_on_missing_type=False, ignore_handler_exceptions=True)
         consumer = EventConsumer(settings.LISTENER_URL,
                                  settings.LISTENER_QUEUE,
                                  dispatcher.dispatch_event,

--- a/tests/unit/test_dispatcher.py
+++ b/tests/unit/test_dispatcher.py
@@ -28,7 +28,7 @@ class TestDispatcher(TestCase):
         self.handler.assert_called_once_with(event)
         other_handler.assert_called_once_with(event)
 
-    def test_that_dispatcher_absorbs_all_exceptions(self):
+    def test_that_dispatcher_does_not_absorb_handler_exceptions(self):
         handler = mock.Mock(__name__='my_handler')
         handler.side_effect = RuntimeError
 
@@ -36,6 +36,18 @@ class TestDispatcher(TestCase):
 
         event = {'type': 'event_type', 'payload': 'some payload'}
         dispatcher = eventhandler.Dispatcher()
+
+        with self.assertRaises(RuntimeError):
+            dispatcher.dispatch_event(event)
+
+    def test_that_dispatcher_absorbs_all_exceptions_when_told_to_do_so(self):
+        handler = mock.Mock(__name__='my_handler')
+        handler.side_effect = RuntimeError
+
+        eventhandler.HANDLERS = {'event_type': [handler, self.handler]}
+
+        event = {'type': 'event_type', 'payload': 'some payload'}
+        dispatcher = eventhandler.Dispatcher(ignore_handler_exceptions=True)
         dispatcher.dispatch_event(event)
 
         self.handler.assert_called_once_with(event)


### PR DESCRIPTION
When testing the event handler, all kinds of exceptions are swallowed. This can take hours to debug. The functionality is only relevant to the event listener daemon, so let's enable that behaviour only in the event listener.

Swallowing is now optional :wink: 