### PR TITLE
Deepcopy the event data before calling the handler. So it is not allowed to edit the evendata

### DIFF
--- a/eventhandler/__init__.py
+++ b/eventhandler/__init__.py
@@ -3,6 +3,8 @@ import logging
 
 from collections import defaultdict
 
+from copy import deepcopy
+
 logger = logging.getLogger(__name__)
 
 HANDLERS = defaultdict(list)
@@ -59,13 +61,13 @@ class Dispatcher(object):
 
             if self.ignore_handler_exceptions:
                 try:
-                    handler(event)
+                    handler(deepcopy(event))
                 except Exception:  # Catch'em all!
                     logger.exception('Event handler raised an exception on {} event'.format(event['type']))
                     logger.debug('Event data: {}'.format(json.dumps(event)))
             else:
                 # separate call, so we do not mess up the stacktrace with try and except
-                handler(event)
+                handler(deepcopy(event))
 
 
 def handles_event(event_type):

--- a/tests/unit/test_dispatcher.py
+++ b/tests/unit/test_dispatcher.py
@@ -102,3 +102,31 @@ class TestDispatcher(TestCase):
         dispatcher.dispatch_event({})
 
         self.assertEqual(len(self.handler.mock_calls), 0)
+
+    def test_that_handler_can_not_change_event_data_for_other_handlers(self):
+        def first_handler(event):
+            event['data'] = 'changed'
+
+        eventhandler.HANDLERS = {'event_type': [first_handler, self.handler]}
+
+        dispatcher = eventhandler.Dispatcher()
+
+        event_tochange = {'type': 'event_type', 'data': 'not_changed'}
+        dispatcher.dispatch_event(event_tochange)
+
+        expected_handler_argument = self.handler.mock_calls[0][1][0]
+        self.assertEqual(expected_handler_argument, {'type': 'event_type', 'data': 'not_changed'})
+
+    def test_that_handler_can_not_change_event_data_for_other_handlers_if_ignore_handler_exceptions(self):
+        def first_handler(event):
+            event['data'] = 'changed'
+
+        eventhandler.HANDLERS = {'event_type': [first_handler, self.handler]}
+
+        dispatcher = eventhandler.Dispatcher(ignore_handler_exceptions=True)
+
+        event_tochange = {'type': 'event_type', 'data': 'not_changed'}
+        dispatcher.dispatch_event(event_tochange)
+
+        expected_handler_argument = self.handler.mock_calls[0][1][0]
+        self.assertEqual(expected_handler_argument, {'type': 'event_type', 'data': 'not_changed'})


### PR DESCRIPTION
Deepcopy the event data before calling the handler. So it is not allowed to edit the evendata

This was what happened to me:
```
In [1]: event = {'data': []}

In [2]: data = event.get('data', [])

In [3]: data
Out[3]: []

In [4]: data.append('foo')

In [5]: data
Out[5]: ['foo']

In [6]: event
Out[6]: {'data': ['foo']}
```