### PR TITLE
only build against master branch - PRs still built separately

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,3 +1,7 @@
+branches:
+  only:
+    - master
+
 language: python
 
 python:


### PR DESCRIPTION
Currently PRs will have 2 build jobs - one for the branch, one for the PR. This is unnecessary.