### PR TITLE
Update amqpconsumer requirement

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -2,7 +2,7 @@ from setuptools import setup, find_packages
 
 setup(
     name='django-eventhandler',
-    version='0.5.3',
+    version='0.5.4',
     packages=find_packages(exclude=['tests*']),
     url='https://github.com/ByteInternet/django-eventhandler',
     author='Byte B.V.',
@@ -23,5 +23,5 @@ setup(
     ],
     keywords='amqp django rabbitmq events eventhandler',
     description='RabbitMQ event handler as a Django module',
-    install_requires=['Django>=1.8', 'amqpconsumer==1.5', 'six==1.11.0'],
+    install_requires=['Django>=1.8', 'amqpconsumer==1.7', 'six==1.11.0'],
 )


### PR DESCRIPTION
This new requirement actually supports python 3 :see_no_evil:
Also bump version