### PR TITLE
Make use of amqpconsumer==1.7.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,3 @@
+<h1>Changelog</h1>
+<h2>0.5.6</h2>
+Make use of `amqpconsumer==1.7.1` so we can work with newer pika versions (no longer references `stop_ioloop_on_close`).

--- a/setup.py
+++ b/setup.py
@@ -2,7 +2,7 @@ from setuptools import setup, find_packages
 
 setup(
     name='django-eventhandler',
-    version='0.5.5',
+    version='0.5.6',
     packages=find_packages(exclude=['tests*']),
     url='https://github.com/ByteInternet/django-eventhandler',
     author='Byte B.V.',
@@ -23,5 +23,5 @@ setup(
     ],
     keywords='amqp django rabbitmq events eventhandler',
     description='RabbitMQ event handler as a Django module',
-    install_requires=['Django>=1.8', 'amqpconsumer==1.7', 'six>=1.11.0'],
+    install_requires=['Django>=1.8', 'amqpconsumer==1.7.1', 'six>=1.11.0'],
 )


### PR DESCRIPTION
So we can make use of newer pika versions (no longer references
`stop_ioloop_on_close`).